### PR TITLE
Add a parameter to throttle calls to Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center"> xGitGuard </h1>
 
-<p align="center">AI-Based Secrets Detection<br> 
+<p align="center">AI-Based Secrets Detection<br>
 <i><b>Detect Secrets (API Tokens, Usernames, Passwords, etc.) Exposed on GitHub Repositories</b></i><br>
 Designed and Developed by Comcast Cybersecurity Research and Development Team</p>
 
@@ -377,7 +377,7 @@ The user needs to follow the below process to collect data and train the model t
 
 - Follow [ML Model Training](#ml-model-training)
 
-> **NOTE** :  
+> **NOTE** :
 > To use ML Feature, ML training is mandatory. It includes data collection,feature engineering & model persisting.
 
 ##### Command to Run Public Keys & Tokens Secret Scanner with ML
@@ -661,7 +661,7 @@ Traverse into the "ml_training" folder
 - Users can add additional extensions to extensions.csv to search types of files other than the default list.
 - Users can enhance secondary_creds.csv/secondary_keys.csv by adding new patterns to do searches other than the default list.
 - Users need to add primary keywords for public search in primary_keywords.csv after removing the sample content.
-- In case of GitHub API calls resulting in 403 due to API rate-limit, increase the sleep time before each API call in file "xgitguard/common/github_calls.py".
+- In case of GitHub API calls resulting in 403 due to API rate-limit, increase the throttle timeout (github.throttle_time: 10) in the config ("config/xgg_configs.yaml)".
 
 ## License
 

--- a/xgitguard/common/github_calls.py
+++ b/xgitguard/common/github_calls.py
@@ -23,222 +23,235 @@ import time
 import requests
 
 logger = logging.getLogger("xgg_logger")
+class GithubCalls:
+
+    def __init__(
+        self,
+        base_url,
+        token_env,
+        commits_api_url,
+    ):
+        assert token_env == "public" or token_env == "enterprise", f"token_env must be either 'public' or 'enterprise'. current: {token_env}"
+        self._base_url = base_url
+        self._token_env = token_env
+        self._commits_api_url = commits_api_url
+
+    def run_github_search(self, search_query, extension):
+        """
+        Run the GitHub API search with given search query
+        Get the items from the response content and Return
+        params: api_url - string - GitHub Search API url
+        params: search_query - string - Search keyword
+        params: extension - string - Search extension
+        returns: search_response - list
+        """
+        logger.debug("<<<< 'Current Executing Function' >>>>")
+        if not extension and extension == "others":
+            response = self.__github_api_get_params(search_query)
+        elif self._token_env == "public":
+
+            response = self.__github_api_get_params(
+                (search_query + " extension:" + extension)
+            )
+        else:
+            response = self.__github_api_get_params(
+                (search_query + "+extension:" + extension)
+            )
+        if response:
+            if response.status_code == 200:
+                content = response.json()
+                search_response = content["items"]
+                return search_response
+            else:
+                time.sleep(2)
+                logger.error(f"Search Response code: {response.status_code}. Continuing...")
+        else:
+            logger.error(
+                f"Search '{search_query}' api call failed as {response}. Continuing..."
+            )
+        return []
 
 
-def run_github_search(api_url, search_query, extension, token_env):
-    """
-    Run the GitHub API search with given search query
-    Get the items from the response content and Return
-    params: api_url - string - GitHub Search API url
-    params: search_query - string - Search keyword
-    params: extension - string - Search extension
-    returns: search_response - list
-    """
-    logger.debug("<<<< 'Current Executing Function' >>>>")
+    def __github_api_get_params(self, search_query):
+        """
+        For the given GITHUB API url and search query, call the api
+        Get and return the response
+        ### Need GitHub Auth Token as Env variable named "GITHUB_TOKEN"
 
-    if not extension and extension == "others":
-        response = github_api_get_params(api_url, search_query, token_env)
-    elif token_env == "public":
-        response = github_api_get_params(
-            api_url, (search_query + " extension:" + extension), token_env
-        )
-    else:
-        response = github_api_get_params(
-            api_url, (search_query + "+extension:" + extension), token_env
-        )
-    if response:
-        if response.status_code == 200:
-            content = response.json()
-            search_response = content["items"]
-            return search_response
+        params: api_url - string
+        params: search_query - string
+        returns: response - dict
+        """
+        logger.debug("<<<< 'Current Executing Function' >>>>")
+        if self._token_env == "public":
+            token_var = "GITHUB_TOKEN"
+            time.sleep(3)
         else:
             time.sleep(2)
-            logger.error(f"Search Response code: {response.status_code}. Continuing...")
-    else:
-        logger.error(
-            f"Search '{search_query}' api call failed as {response}. Continuing..."
-        )
-    return []
+            token_var = "GITHUB_ENTERPRISE_TOKEN"
+            if "<< Enterprise Name >>" in self._base_url:
+                logger.error(
+                    f"GitHub API URL not set for Enterprise in xgg_configs.yaml file in config folder. API Search will fail/return no results. Please Setup and retry"
+                )
+                sys.exit(1)
 
-
-def github_api_get_params(api_url, search_query, token_env):
-    """
-    For the given GITHUB API url and search query, call the api
-    Get and return the response
-    ### Need GitHub Auth Token as Env variable named "GITHUB_TOKEN"
-
-    params: api_url - string
-    params: search_query - string
-    returns: response - dict
-    """
-    logger.debug("<<<< 'Current Executing Function' >>>>")
-    if token_env == "public":
-        token_var = "GITHUB_TOKEN"
-        time.sleep(3)
-    else:
-        time.sleep(2)
-        token_var = "GITHUB_ENTERPRISE_TOKEN"
-        if "<< Enterprise Name >>" in api_url:
+        if not os.getenv(token_var):
             logger.error(
-                f"GitHub API URL not set for Enterprise in xgg_configs.yaml file in config folder. API Search will fail/return no results. Please Setup and retry"
+                f"GitHub API Token Environment variable '{token_var}' not set. API Search will fail/return no results. Please Setup and retry"
             )
             sys.exit(1)
 
-    if not os.getenv(token_var):
-        logger.error(
-            f"GitHub API Token Environment variable '{token_var}' not set. API Search will fail/return no results. Please Setup and retry"
+        try:
+
+            response = requests.get(
+                self._base_url,
+                params={
+                    "q": search_query,
+                    "order": "desc",
+                    "sort": "indexed",
+                    "per_page": 100,
+                },
+                auth=("token", os.getenv(token_var)),
+            )
+
+            return response
+
+        except Exception as e:
+            logger.error(f"Github API call Error: {e}")
+
+        return {}
+
+
+    def public_url_content_get(self):
+        """
+        For the given GitHub url, call the api
+        Get and return the response
+        ### Need GitHub Auth Token as Env variable named "GITHUB_TOKEN"
+
+        params: api_url - string
+        returns: response - string
+        """
+        logger.debug("<<<< 'Current Executing Function' >>>>")
+
+        token_key = "GITHUB_TOKEN"
+        if not os.getenv(token_key):
+            logger.error(
+                f"GitHub API Token Environment variable '{token_key}' not set. API Search will fail/return no results. Please Setup and retry"
+            )
+            sys.exit(1)
+
+        try:
+            time.sleep(3)
+            response = requests.get(
+                self._base_url, auth=("token", os.getenv(token_key)), timeout=10
+            )
+            return response
+        except Exception as e:
+            logger.error(f"Github API file content get Error: {e}")
+
+        return {}
+
+
+    def enterprise_url_content_get(self, header):
+        """
+        For the given GitHub url, call the api
+        Get and return the response
+        ### Need GitHub Auth Token as Env variable named "GITHUB_ENTERPRISE_TOKEN"
+
+        params: api_url - string
+        returns: response - string
+        """
+        logger.debug("<<<< 'Current Executing Function' >>>>")
+
+        token_key = "GITHUB_ENTERPRISE_TOKEN"
+        if not os.getenv(token_key):
+            logger.error(
+                f"GitHub API Token Environment variable '{token_key}' not set. API Search will fail/return no results. Please Setup and retry"
+            )
+            sys.exit(1)
+        elif "<< Enterprise Name >>" in self._base_url:
+            logger.error(
+                f"GitHub API Content URL not set for Enterprise in xgg_configs.yaml file in config folder. API Search will fail/return no results. Please Setup and retry"
+            )
+            sys.exit(1)
+
+        try:
+            time.sleep(2)
+            response = requests.get(
+                self._base_url,
+                auth=("token", os.getenv(token_key)),
+                headers=header,
+                timeout=10,
+            )
+            return response
+        except Exception as e:
+            logger.error(f"Github API file content get Error: {e}")
+
+        return {}
+
+
+    def get_github_public_commits(self, user_name, repo_name, file_path):
+        """
+        For the given GitHub details, call the api and get commit details
+        Get and return the response
+        ### Need GitHub Auth Token as Env variable named "GITHUB_TOKEN"
+        params: commits_api_url - string
+        returns: response - string
+        """
+        logger.debug("<<<< 'Current Executing Function' >>>>")
+        full_commit_url = self._commits_api_url.format(
+            user_name=user_name, repo_name=repo_name, file_path=file_path
         )
-        sys.exit(1)
+        token_var = "GITHUB_TOKEN"
+        if not os.getenv(token_var):
+            logger.error(
+                f"GitHub API Token Environment variable '{token_var}' not set. API Search will fail/return no results. Please Setup and retry"
+            )
+            sys.exit(1)
 
-    try:
-
-        response = requests.get(
-            api_url,
-            params={
-                "q": search_query,
-                "order": "desc",
-                "sort": "indexed",
-                "per_page": 100,
-            },
-            auth=("token", os.getenv(token_var)),
-        )
-
-        return response
-
-    except Exception as e:
-        logger.error(f"Github API call Error: {e}")
-
-    return {}
+        try:
+            time.sleep(3)
+            response = requests.get(
+                full_commit_url, auth=("token", os.getenv(token_var)), timeout=25
+            )
+            return response
+        except Exception as e:
+            logger.error(f"Github API commit content get Error: {e}")
+        return {}
 
 
-def public_url_content_get(api_url):
-    """
-    For the given GitHub url, call the api
-    Get and return the response
-    ### Need GitHub Auth Token as Env variable named "GITHUB_TOKEN"
+    def get_github_enterprise_commits(self, header):
+        """
+        For the given GitHub details, call the api and get commit details
+        Get and return the response
+        ### Need GitHub Enterprise Auth Token as Env variable named "GITHUB_ENTERPRISE_TOKEN"
+        params: commits_api_url - string
+        params: header - dict
+        returns: response - string
+        """
+        logger.debug("<<<< 'Current Executing Function' >>>>")
 
-    params: api_url - string
-    returns: response - string
-    """
-    logger.debug("<<<< 'Current Executing Function' >>>>")
+        token_var = "GITHUB_ENTERPRISE_TOKEN"
+        if not os.getenv(token_var):
+            logger.error(
+                f"GitHub API Token Environment variable '{token_var}' not set. API Search will fail/return no results. Please Setup and retry"
+            )
+            sys.exit(1)
+        elif "<< Enterprise Name >>" in self._commits_api_url:
+            logger.error(
+                f"GitHub API Commits URL not set for Enterprise in xgg_configs.yaml file in config folder. API Search will fail/return no results. Please Setup and retry"
+            )
+            sys.exit(1)
 
-    token_var = "GITHUB_TOKEN"
-    if not os.getenv(token_var):
-        logger.error(
-            f"GitHub API Token Environment variable '{token_var}' not set. API Search will fail/return no results. Please Setup and retry"
-        )
-        sys.exit(1)
-
-    try:
-        time.sleep(3)
-        response = requests.get(
-            api_url, auth=("token", os.getenv(token_var)), timeout=10
-        )
-        return response
-    except Exception as e:
-        logger.error(f"Github API file content get Error: {e}")
-
-    return {}
-
-
-def enterprise_url_content_get(api_url, header):
-    """
-    For the given GitHub url, call the api
-    Get and return the response
-    ### Need GitHub Auth Token as Env variable named "GITHUB_ENTERPRISE_TOKEN"
-
-    params: api_url - string
-    returns: response - string
-    """
-    logger.debug("<<<< 'Current Executing Function' >>>>")
-
-    token_var = "GITHUB_ENTERPRISE_TOKEN"
-    if not os.getenv(token_var):
-        logger.error(
-            f"GitHub API Token Environment variable '{token_var}' not set. API Search will fail/return no results. Please Setup and retry"
-        )
-        sys.exit(1)
-    elif "<< Enterprise Name >>" in api_url:
-        logger.error(
-            f"GitHub API Content URL not set for Enterprise in xgg_configs.yaml file in config folder. API Search will fail/return no results. Please Setup and retry"
-        )
-        sys.exit(1)
-
-    try:
-        time.sleep(2)
-        response = requests.get(
-            api_url,
-            auth=("token", os.getenv(token_var)),
-            headers=header,
-            timeout=10,
-        )
-        return response
-    except Exception as e:
-        logger.error(f"Github API file content get Error: {e}")
-
-    return {}
-
-
-def get_github_public_commits(commits_api_url):
-    """
-    For the given GitHub details, call the api and get commit details
-    Get and return the response
-    ### Need GitHub Auth Token as Env variable named "GITHUB_TOKEN"
-    params: commits_api_url - string
-    returns: response - string
-    """
-    logger.debug("<<<< 'Current Executing Function' >>>>")
-
-    token_var = "GITHUB_TOKEN"
-    if not os.getenv(token_var):
-        logger.error(
-            f"GitHub API Token Environment variable '{token_var}' not set. API Search will fail/return no results. Please Setup and retry"
-        )
-        sys.exit(1)
-
-    try:
-        time.sleep(3)
-        response = requests.get(
-            commits_api_url, auth=("token", os.getenv(token_var)), timeout=25
-        )
-        return response
-    except Exception as e:
-        logger.error(f"Github API commit content get Error: {e}")
-    return {}
-
-
-def get_github_enterprise_commits(commits_api_url, header):
-    """
-    For the given GitHub details, call the api and get commit details
-    Get and return the response
-    ### Need GitHub Enterprise Auth Token as Env variable named "GITHUB_ENTERPRISE_TOKEN"
-    params: commits_api_url - string
-    params: header - dict
-    returns: response - string
-    """
-    logger.debug("<<<< 'Current Executing Function' >>>>")
-
-    token_var = "GITHUB_ENTERPRISE_TOKEN"
-    if not os.getenv(token_var):
-        logger.error(
-            f"GitHub API Token Environment variable '{token_var}' not set. API Search will fail/return no results. Please Setup and retry"
-        )
-        sys.exit(1)
-    elif "<< Enterprise Name >>" in commits_api_url:
-        logger.error(
-            f"GitHub API Commits URL not set for Enterprise in xgg_configs.yaml file in config folder. API Search will fail/return no results. Please Setup and retry"
-        )
-        sys.exit(1)
-
-    try:
-        time.sleep(3)
-        response = requests.get(
-            commits_api_url,
-            auth=("token", os.getenv(token_var)),
-            headers=header,
-            timeout=25,
-        )
-        return response
-    except Exception as e:
-        logger.error(f"Github API commit content get Error: {e}")
-    return {}
+        try:
+            time.sleep(3)
+            response = requests.get(
+                self._commits_api_url,
+                auth=("token", os.getenv(token_var)),
+                headers=header,
+                timeout=25,
+            )
+            return response
+        except Exception as e:
+            logger.error(f"Github API commit content get Error: {e}")
+        return {}

--- a/xgitguard/common/github_calls.py
+++ b/xgitguard/common/github_calls.py
@@ -124,7 +124,7 @@ class GithubCalls:
         return {}
 
 
-    def public_url_content_get(self):
+    def public_url_content_get(self, file_url):
         """
         For the given GitHub url, call the api
         Get and return the response
@@ -145,7 +145,7 @@ class GithubCalls:
         try:
             time.sleep(self._throttle_time)
             response = requests.get(
-                self._base_url, auth=("token", os.getenv(token_key)), timeout=10
+                file_url, auth=("token", os.getenv(token_key)), timeout=10
             )
             return response
         except Exception as e:
@@ -154,7 +154,7 @@ class GithubCalls:
         return {}
 
 
-    def enterprise_url_content_get(self, header):
+    def enterprise_url_content_get(self, file_url, header):
         """
         For the given GitHub url, call the api
         Get and return the response
@@ -180,7 +180,7 @@ class GithubCalls:
         try:
             time.sleep(self._throttle_time)
             response = requests.get(
-                self._base_url,
+                file_url,
                 auth=("token", os.getenv(token_key)),
                 headers=header,
                 timeout=10,
@@ -222,7 +222,7 @@ class GithubCalls:
         return {}
 
 
-    def get_github_enterprise_commits(self, header):
+    def get_github_enterprise_commits(self, user_name, repo_name, file_path, header):
         """
         For the given GitHub details, call the api and get commit details
         Get and return the response
@@ -247,8 +247,11 @@ class GithubCalls:
 
         try:
             time.sleep(self._throttle_time)
+            full_commit_url = self._commits_api_url.format(
+                user_name=user_name, repo_name=repo_name, file_path=file_path
+            )
             response = requests.get(
-                self._commits_api_url,
+                full_commit_url,
                 auth=("token", os.getenv(token_var)),
                 headers=header,
                 timeout=25,

--- a/xgitguard/common/github_calls.py
+++ b/xgitguard/common/github_calls.py
@@ -30,11 +30,13 @@ class GithubCalls:
         base_url,
         token_env,
         commits_api_url,
+        throttle_time=2
     ):
         assert token_env == "public" or token_env == "enterprise", f"token_env must be either 'public' or 'enterprise'. current: {token_env}"
         self._base_url = base_url
         self._token_env = token_env
         self._commits_api_url = commits_api_url
+        self._throttle_time = throttle_time
 
     def run_github_search(self, search_query, extension):
         """
@@ -63,7 +65,7 @@ class GithubCalls:
                 search_response = content["items"]
                 return search_response
             else:
-                time.sleep(2)
+                time.sleep(self._throttle_time)
                 logger.error(f"Search Response code: {response.status_code}. Continuing...")
         else:
             logger.error(
@@ -85,9 +87,9 @@ class GithubCalls:
         logger.debug("<<<< 'Current Executing Function' >>>>")
         if self._token_env == "public":
             token_var = "GITHUB_TOKEN"
-            time.sleep(3)
+            time.sleep(self._throttle_time)
         else:
-            time.sleep(2)
+            time.sleep(self._throttle_time)
             token_var = "GITHUB_ENTERPRISE_TOKEN"
             if "<< Enterprise Name >>" in self._base_url:
                 logger.error(
@@ -141,7 +143,7 @@ class GithubCalls:
             sys.exit(1)
 
         try:
-            time.sleep(3)
+            time.sleep(self._throttle_time)
             response = requests.get(
                 self._base_url, auth=("token", os.getenv(token_key)), timeout=10
             )
@@ -176,7 +178,7 @@ class GithubCalls:
             sys.exit(1)
 
         try:
-            time.sleep(2)
+            time.sleep(self._throttle_time)
             response = requests.get(
                 self._base_url,
                 auth=("token", os.getenv(token_key)),
@@ -210,7 +212,7 @@ class GithubCalls:
             sys.exit(1)
 
         try:
-            time.sleep(3)
+            time.sleep(self._throttle_time)
             response = requests.get(
                 full_commit_url, auth=("token", os.getenv(token_var)), timeout=25
             )
@@ -244,7 +246,7 @@ class GithubCalls:
             sys.exit(1)
 
         try:
-            time.sleep(3)
+            time.sleep(self._throttle_time)
             response = requests.get(
                 self._commits_api_url,
                 auth=("token", os.getenv(token_var)),

--- a/xgitguard/config/xgg_configs.yaml
+++ b/xgitguard/config/xgg_configs.yaml
@@ -3,6 +3,7 @@ default:
   log_dir: None
 
 github:
+  throttle_time: 10
   # GitHub Public
   public_api_url: "https://api.github.com/search/code"
   public_commits_url: "https://api.github.com/repos/%s/%s/commits?path=%s"

--- a/xgitguard/github-enterprise/enterprise_cred_detections.py
+++ b/xgitguard/github-enterprise/enterprise_cred_detections.py
@@ -152,11 +152,13 @@ def format_detection(skeyword, org_url, url, code_content, secrets, skeyword_cou
 
     try:
         file_path = url.split("/contents/")[1]
-        commits_api_url = configs.xgg_configs["github"][
-            "enterprise_commits_url"
-        ].format(user_name=user_name, repo_name=repo_name, file_path=file_path)
         header = configs.xgg_configs["github"]["enterprise_header"]
-        api_response_commit_data = githubCalls.get_github_enterprise_commits( header)
+        api_response_commit_data = githubCalls.get_github_enterprise_commits(
+            user_name,
+            repo_name,
+            file_path,
+            header,
+        )
         commit_details = format_commit_details(api_response_commit_data)
     except Exception as e:
         logger.warning(f"Github commit content formation error: {e}")
@@ -264,7 +266,7 @@ def process_search_urls(org_urls_list, url_list, search_query):
     try:
         for url in url_list:
             header = configs.xgg_configs["github"]["enterprise_header"]
-            code_content_response = githubCalls.enterprise_url_content_get(header)
+            code_content_response = githubCalls.enterprise_url_content_get(url, header)
             if code_content_response:
                 code_content = code_content_response.text
             else:

--- a/xgitguard/github-enterprise/enterprise_cred_detections.py
+++ b/xgitguard/github-enterprise/enterprise_cred_detections.py
@@ -37,10 +37,10 @@ xGitGuard Enterprise GitHub Credential Detection Process
 
     # Run with Secondary Keywords and Extensions from config files:
     python enterprise_cred_detections.py
-    
+
     # Run with Secondary Keywords from config file and given list of Extensions:
     python enterprise_cred_detections.py -e "py,txt"
-    
+
     # Run for given Secondary Keyword and Extension without ML prediction:
     python enterprise_cred_detections.py -s "password" -e "py"
 
@@ -71,11 +71,7 @@ from common.data_format import (
     format_commit_details,
     remove_url_from_creds,
 )
-from common.github_calls import (
-    enterprise_url_content_get,
-    get_github_enterprise_commits,
-    run_github_search,
-)
+from common.github_calls import GithubCalls
 from common.logger import create_logger
 from common.ml_process import entropy_calc, ml_prediction_process
 from ml_training.model import xgg_train_model
@@ -160,9 +156,7 @@ def format_detection(skeyword, org_url, url, code_content, secrets, skeyword_cou
             "enterprise_commits_url"
         ].format(user_name=user_name, repo_name=repo_name, file_path=file_path)
         header = configs.xgg_configs["github"]["enterprise_header"]
-        api_response_commit_data = get_github_enterprise_commits(
-            commits_api_url, header
-        )
+        api_response_commit_data = githubCalls.get_github_enterprise_commits( header)
         commit_details = format_commit_details(api_response_commit_data)
     except Exception as e:
         logger.warning(f"Github commit content formation error: {e}")
@@ -270,7 +264,7 @@ def process_search_urls(org_urls_list, url_list, search_query):
     try:
         for url in url_list:
             header = configs.xgg_configs["github"]["enterprise_header"]
-            code_content_response = enterprise_url_content_get(url, header)
+            code_content_response = githubCalls.enterprise_url_content_get(header)
             if code_content_response:
                 code_content = code_content_response.text
             else:
@@ -578,14 +572,6 @@ def run_detection(secondary_keywords=[], extensions=[], ml_prediction=False):
         run_detection(extension = ["py","txt"])
     """
     logger.debug("<<<< 'Current Executing Function' >>>>")
-    # Read and Setup Global Configuration Data to reference in all process
-    try:
-        global configs
-        if configs:
-            pass
-    except:
-        # Setting Global configuration Data
-        configs = ConfigsData()
 
     if secondary_keywords:
         if isinstance(secondary_keywords, list):
@@ -649,11 +635,9 @@ def run_detection(secondary_keywords=[], extensions=[], ml_prediction=False):
             try:
                 # Search GitHub and return search response confidence_score
                 total_processed_search += 1
-                search_response_lines = run_github_search(
-                    configs.xgg_configs["github"]["enterprise_api_url"],
+                search_response_lines = githubCalls.run_github_search(
                     search_query,
                     extension,
-                    "enterprise",
                 )
                 # If search has detections, process the result urls else continue next search
                 if search_response_lines:
@@ -843,6 +827,13 @@ if __name__ == "__main__":
 
     # Setting up Logger
     setup_logger(log_level, console_logging)
+
+    configs = ConfigsData()
+    githubCalls = GithubCalls(
+        configs.xgg_configs["github"]["enterprise_api_url"],
+        "enterprise",
+        configs.xgg_configs["github"]["public_commits_url"],
+    )
 
     logger.info("xGitGuard Credentials Detection Process Started")
     if ml_prediction:

--- a/xgitguard/github-enterprise/enterprise_key_detections.py
+++ b/xgitguard/github-enterprise/enterprise_key_detections.py
@@ -37,10 +37,10 @@ xGitGuard Enterprise GitHub Keys and Token Detection Process
 
     # Run with Secondary Keywords and Extensions from config files:
     python enterprise_key_detections.py
-    
+
     # Run with Secondary Keywords and Extensions from config files with ML prediction:
     python enterprise_key_detections.py -m Yes
-    
+
     # Run with Secondary Keywords from config file and given list of Extensions:
     python enterprise_key_detections.py -e "py,txt"
 
@@ -153,11 +153,13 @@ def format_detection(skeyword, org_url, url, code_content, secrets, skeyword_cou
 
     try:
         file_path = url.split("/contents/")[1]
-        commits_api_url = configs.xgg_configs["github"][
-            "enterprise_commits_url"
-        ].format(user_name=user_name, repo_name=repo_name, file_path=file_path)
         header = configs.xgg_configs["github"]["enterprise_header"]
-        api_response_commit_data = githubCalls.get_github_enterprise_commits( header)
+        api_response_commit_data = githubCalls.get_github_enterprise_commits(
+            user_name,
+            repo_name,
+            file_path,
+            header,
+        )
         commit_details = format_commit_details(api_response_commit_data)
     except Exception as e:
         logger.warning(f"Github commit content formation error: {e}")
@@ -249,7 +251,7 @@ def process_search_urls(org_urls_list, url_list, search_query):
     try:
         for url in url_list:
             header = configs.xgg_configs["github"]["enterprise_header"]
-            code_content_response = githubCalls.enterprise_url_content_get(header)
+            code_content_response = githubCalls.enterprise_url_content_get(url, header)
             if code_content_response:
                 code_content = code_content_response.text
             else:

--- a/xgitguard/github-public/public_cred_detections.py
+++ b/xgitguard/github-public/public_cred_detections.py
@@ -266,7 +266,7 @@ def process_search_urls(url_list, search_query):
     extractor = URLExtract()
     try:
         for url in url_list:
-            code_content_response = githubCalls.public_url_content_get()
+            code_content_response = githubCalls.public_url_content_get(url)
             if code_content_response:
                 code_content = code_content_response.text
             else:

--- a/xgitguard/github-public/public_cred_detections.py
+++ b/xgitguard/github-public/public_cred_detections.py
@@ -993,6 +993,7 @@ if __name__ == "__main__":
         configs.xgg_configs["github"]["public_api_url"],
         "public",
         configs.xgg_configs["github"]["public_commits_url"],
+        configs.xgg_configs["github"]["throttle_time"],
     )
 
     logger.info("xGitGuard Credentials Detection Process Started")

--- a/xgitguard/github-public/public_key_detections.py
+++ b/xgitguard/github-public/public_key_detections.py
@@ -37,7 +37,7 @@ xGitGuard Public GitHub Keys and Token Detection process
 
     # Run with Primary Keywords, Secondary Keywords and Extensions from config files:
     python public_key_detections.py
-    
+
     # Run with Primary Keywords, Secondary Keywords and Extensions from config files with ML:
     python public_key_detections.py -m Yes
 
@@ -72,11 +72,7 @@ from common.data_format import (
     keys_extractor,
     remove_url_from_keys,
 )
-from common.github_calls import (
-    get_github_public_commits,
-    public_url_content_get,
-    run_github_search,
-)
+from common.github_calls import GithubCalls
 from common.logger import create_logger
 from common.ml_process import entropy_calc, ml_prediction_process
 from ml_training.model import xgg_train_model
@@ -160,10 +156,9 @@ def format_detection(pkeyword, skeyword, url, code_content, secrets, keyword_cou
 
     try:
         file_path = "/".join(raw_url_splits[1].split("/")[2:])
-        commits_api_url = configs.xgg_configs["github"]["public_commits_url"].format(
-            user_name=user_name, repo_name=repo_name, file_path=file_path
+        api_response_commit_data = githubCalls.get_github_public_commits(
+            user_name, repo_name, file_path
         )
-        api_response_commit_data = get_github_public_commits(commits_api_url)
         commit_details = format_commit_details(api_response_commit_data)
     except Exception as e:
         logger.warning(f"Github commit content formation error: {e}")
@@ -253,7 +248,7 @@ def process_search_urls(url_list, search_query):
     extractor = URLExtract()
     try:
         for url in url_list:
-            code_content_response = public_url_content_get(url)
+            code_content_response = githubCalls.public_url_content_get()
             if code_content_response:
                 code_content = code_content_response.text
             else:
@@ -559,14 +554,6 @@ def run_detection(
         run_detection(extension = ["py","txt"])
     """
     logger.debug("<<<< 'Current Executing Function' >>>>")
-    # Read and Setup Global Configuration Data to reference in all process
-    try:
-        global configs
-        if configs:
-            pass
-    except:
-        # Setting Global configuration Data
-        configs = ConfigsData()
 
     if secondary_keywords:
         if isinstance(secondary_keywords, list):
@@ -645,11 +632,9 @@ def run_detection(
             try:
                 # Search GitHub and return search response confidence_score
                 total_processed_search += 1
-                search_response_lines = run_github_search(
-                    configs.xgg_configs["github"]["public_api_url"],
+                search_response_lines = githubCalls.run_github_search(
                     search_query,
                     extension,
-                    "public",
                 )
                 # If search has detections, process the result urls else continue next search
                 if search_response_lines:
@@ -699,9 +684,6 @@ def run_detections_from_file(secondary_keywords=[], extensions=[], ml_prediction
     returns: None
     """
     logger.debug("<<<< 'Current Executing Function' >>>>")
-    # Setting Global configuration Data
-    global configs
-    configs = ConfigsData()
 
     # Get the Primary Keywords from Primary Keywords file
     configs.read_primary_keywords(file_name="primary_keywords.csv")
@@ -776,9 +758,6 @@ def run_detections_from_list(
 
         total_key_runs, success_key_runs = 0, 0
 
-        # Setting Global configuration Data
-        global configs
-        configs = ConfigsData()
         for primary_keyword in primary_keywords:
             if primary_keyword is None:
                 continue
@@ -983,7 +962,15 @@ if __name__ == "__main__":
     # Setting up Logger
     setup_logger(log_level, console_logging)
 
-    logger.info("xGitGuard Keys and Token Detection Process Started")
+    # Read and Setup Global Configuration Data to reference in all process
+    configs = ConfigsData()
+    githubCalls = GithubCalls(
+        configs.xgg_configs["github"]["public_api_url"],
+        "public",
+        configs.xgg_configs["github"]["public_commits_url"],
+    )
+
+    logger.info("xGitGuard Credentials Detection Process Started")
     if ml_prediction:
         logger.info("Running the xGitGuard detection with ML Prediction filter")
     else:

--- a/xgitguard/github-public/public_key_detections.py
+++ b/xgitguard/github-public/public_key_detections.py
@@ -248,7 +248,7 @@ def process_search_urls(url_list, search_query):
     extractor = URLExtract()
     try:
         for url in url_list:
-            code_content_response = githubCalls.public_url_content_get()
+            code_content_response = githubCalls.public_url_content_get(url)
             if code_content_response:
                 code_content = code_content_response.text
             else:
@@ -274,7 +274,6 @@ def process_search_urls(url_list, search_query):
                     f"Skiping processing URL extract from code content as url lines is beyond 2: {len(lines)}"
                 )
                 continue
-
             code_contents = remove_url_from_keys(code_content)
             secrets_data = keys_extractor(code_contents)
 

--- a/xgitguard/github-public/public_key_detections.py
+++ b/xgitguard/github-public/public_key_detections.py
@@ -968,6 +968,7 @@ if __name__ == "__main__":
         configs.xgg_configs["github"]["public_api_url"],
         "public",
         configs.xgg_configs["github"]["public_commits_url"],
+        configs.xgg_configs["github"]["throttle_time"],
     )
 
     logger.info("xGitGuard Credentials Detection Process Started")

--- a/xgitguard/ml_training/ml_data-collector/github-enterprise-ml-data_collector/enterprise_cred_data_collector.py
+++ b/xgitguard/ml_training/ml_data-collector/github-enterprise-ml-data_collector/enterprise_cred_data_collector.py
@@ -218,7 +218,7 @@ def process_search_urls(org_urls_list, url_list, search_query):
     try:
         for url in url_list:
             header = configs.xgg_configs["github"]["enterprise_header"]
-            code_content_response = githubCalls.enterprise_url_content_get(header)
+            code_content_response = githubCalls.enterprise_url_content_get(url, header)
             if code_content_response:
                 code_content = code_content_response.text
             else:

--- a/xgitguard/ml_training/ml_data-collector/github-enterprise-ml-data_collector/enterprise_cred_data_collector.py
+++ b/xgitguard/ml_training/ml_data-collector/github-enterprise-ml-data_collector/enterprise_cred_data_collector.py
@@ -51,9 +51,9 @@ MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
 parent_dir = os.path.dirname(os.path.dirname(os.path.dirname(MODULE_DIR)))
 sys.path.insert(0, parent_dir)
 
+from common.github_calls import GithubCalls
 from common.configs_read import ConfigsData
 from common.data_format import credential_extractor, remove_url_from_creds
-from common.github_calls import enterprise_url_content_get, run_github_search
 from common.logger import create_logger
 from common.ml_process import entropy_calc
 from utilities.common_utilities import check_github_token_env
@@ -218,7 +218,7 @@ def process_search_urls(org_urls_list, url_list, search_query):
     try:
         for url in url_list:
             header = configs.xgg_configs["github"]["enterprise_header"]
-            code_content_response = enterprise_url_content_get(url, header)
+            code_content_response = githubCalls.enterprise_url_content_get(header)
             if code_content_response:
                 code_content = code_content_response.text
             else:
@@ -242,7 +242,7 @@ def process_search_urls(org_urls_list, url_list, search_query):
             lines = code_content.split("\n")
             if len(lines) <= 2:
                 logger.debug(
-                    f"Skiping processing URL extract from code content as url lines is beyond 2: {len(lines)}"
+                    f"Skipping processing URL extract from code content as url lines is beyond 2: {len(lines)}"
                 )
                 continue
 
@@ -492,14 +492,6 @@ def run_data_collector(secondary_keywords=[], extensions=[]):
         run_data_collector(extension = ["py","txt"])
     """
     logger.debug("<<<< 'Current Executing Function' >>>>")
-    # Read and Setup Global Configuration Data to reference in all process
-    try:
-        global configs
-        if configs:
-            pass
-    except:
-        # Setting Global configuration Data
-        configs = ConfigsData()
 
     if secondary_keywords:
         if isinstance(secondary_keywords, list):
@@ -547,11 +539,9 @@ def run_data_collector(secondary_keywords=[], extensions=[]):
                 # Search GitHub and return search response confidence_score
                 total_processed_search += 1
                 # time.sleep(2)
-                search_response_lines = run_github_search(
-                    configs.xgg_configs["github"]["enterprise_api_url"],
+                search_response_lines = githubCalls.run_github_search(
                     search_query,
                     extension,
-                    "enterprise",
                 )
                 # If search has detections, process the result urls else continue next search
                 if search_response_lines:
@@ -694,6 +684,14 @@ if __name__ == "__main__":
     setup_logger(log_level, console_logging)
 
     logger.info("xGitGuard Enterprise Credentials Data Collection Process Started")
+
+    configs = ConfigsData()
+    githubCalls = GithubCalls(
+        configs.xgg_configs["github"]["public_api_url"],
+        "public",
+        configs.xgg_configs["github"]["public_commits_url"],
+    )
+
     valid_config, token_var = check_github_token_env("enterprise")
     if not valid_config:
         logger.error(

--- a/xgitguard/ml_training/ml_data-collector/github-enterprise-ml-data_collector/enterprise_key_data_collector.py
+++ b/xgitguard/ml_training/ml_data-collector/github-enterprise-ml-data_collector/enterprise_key_data_collector.py
@@ -204,7 +204,7 @@ def process_search_urls(org_urls_list, url_list, search_query):
     try:
         for url in url_list:
             header = configs.xgg_configs["github"]["enterprise_header"]
-            code_content_response = githubCalls.enterprise_url_content_get(header)
+            code_content_response = githubCalls.enterprise_url_content_get(url, header)
             if code_content_response:
                 code_content = code_content_response.text
             else:

--- a/xgitguard/ml_training/ml_data-collector/github-enterprise-ml-data_collector/enterprise_key_data_collector.py
+++ b/xgitguard/ml_training/ml_data-collector/github-enterprise-ml-data_collector/enterprise_key_data_collector.py
@@ -51,9 +51,9 @@ MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
 parent_dir = os.path.dirname(os.path.dirname(os.path.dirname(MODULE_DIR)))
 sys.path.insert(0, parent_dir)
 
+from common.github_calls import GithubCalls
 from common.configs_read import ConfigsData
 from common.data_format import keys_extractor, remove_url_from_keys
-from common.github_calls import enterprise_url_content_get, run_github_search
 from common.logger import create_logger
 from common.ml_process import entropy_calc
 from utilities.common_utilities import check_github_token_env
@@ -204,7 +204,7 @@ def process_search_urls(org_urls_list, url_list, search_query):
     try:
         for url in url_list:
             header = configs.xgg_configs["github"]["enterprise_header"]
-            code_content_response = enterprise_url_content_get(url, header)
+            code_content_response = githubCalls.enterprise_url_content_get(header)
             if code_content_response:
                 code_content = code_content_response.text
             else:
@@ -471,14 +471,6 @@ def run_data_collector(secondary_keywords=[], extensions=[]):
         run_data_collector(extension = ["py","txt"])
     """
     logger.debug("<<<< 'Current Executing Function' >>>>")
-    # Read and Setup Global Configuration Data to reference in all process
-    try:
-        global configs
-        if configs:
-            pass
-    except:
-        # Setting Global configuration Data
-        configs = ConfigsData()
 
     if secondary_keywords:
         if isinstance(secondary_keywords, list):
@@ -526,11 +518,9 @@ def run_data_collector(secondary_keywords=[], extensions=[]):
                 # Search GitHub and return search response confidence_score
                 total_processed_search += 1
                 # time.sleep(2)
-                search_response_lines = run_github_search(
-                    configs.xgg_configs["github"]["enterprise_api_url"],
+                search_response_lines = githubCalls.run_github_search(
                     search_query,
                     extension,
-                    "enterprise",
                 )
                 # If search has detections, process the result urls else continue next search
                 if search_response_lines:
@@ -673,6 +663,14 @@ if __name__ == "__main__":
     setup_logger(log_level, console_logging)
 
     logger.info("xGitGuard Enterprise Keys and Token Data Collection Process Started")
+
+    configs = ConfigsData()
+    githubCalls = GithubCalls(
+        configs.xgg_configs["github"]["public_api_url"],
+        "public",
+        configs.xgg_configs["github"]["public_commits_url"],
+    )
+
     valid_config, token_var = check_github_token_env("enterprise")
     if not valid_config:
         logger.error(

--- a/xgitguard/ml_training/ml_data-collector/github-public-ml-data_collector/public_cred_data_collector.py
+++ b/xgitguard/ml_training/ml_data-collector/github-public-ml-data_collector/public_cred_data_collector.py
@@ -841,6 +841,7 @@ if __name__ == "__main__":
         configs.xgg_configs["github"]["public_api_url"],
         "public",
         configs.xgg_configs["github"]["public_commits_url"],
+        configs.xgg_configs["github"]["throttle_time"],
     )
 
     valid_config, token_var = check_github_token_env("public")

--- a/xgitguard/ml_training/ml_data-collector/github-public-ml-data_collector/public_key_data_collector.py
+++ b/xgitguard/ml_training/ml_data-collector/github-public-ml-data_collector/public_key_data_collector.py
@@ -54,9 +54,9 @@ MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
 parent_dir = os.path.dirname(os.path.dirname(os.path.dirname(MODULE_DIR)))
 sys.path.insert(0, parent_dir)
 
+from common.github_calls import GithubCalls
 from common.configs_read import ConfigsData
 from common.data_format import keys_extractor, remove_url_from_keys
-from common.github_calls import public_url_content_get, run_github_search
 from common.logger import create_logger
 from common.ml_process import entropy_calc
 from utilities.common_utilities import check_github_token_env
@@ -210,7 +210,7 @@ def process_search_urls(url_list, search_query):
     extractor = URLExtract()
     try:
         for url in url_list:
-            code_content_response = public_url_content_get(url)
+            code_content_response = githubCalls.public_url_content_get()
             if code_content_response:
                 code_content = code_content_response.text
             else:
@@ -475,14 +475,6 @@ def run_data_collector(primary_keyword="", secondary_keywords=[], extensions=[])
         run_data_collector(extension = ["py","txt"])
     """
     logger.debug("<<<< 'Current Executing Function' >>>>")
-    # Read and Setup Global Configuration Data to reference in all process
-    try:
-        global configs
-        if configs:
-            pass
-    except:
-        # Setting Global configuration Data
-        configs = ConfigsData()
 
     if secondary_keywords:
         if isinstance(secondary_keywords, list):
@@ -540,11 +532,9 @@ def run_data_collector(primary_keyword="", secondary_keywords=[], extensions=[])
                 # Search GitHub and return search response confidence_score
                 total_processed_search += 1
                 time.sleep(2)
-                search_response_lines = run_github_search(
-                    configs.xgg_configs["github"]["public_api_url"],
+                search_response_lines = githubCalls.run_github_search(
                     search_query,
                     extension,
-                    "public",
                 )
                 # If search has detections, process the result urls else continue next search
                 if search_response_lines:
@@ -591,9 +581,6 @@ def run_data_collector_from_file(secondary_keywords=[], extensions=[]):
     returns: None
     """
     logger.debug("<<<< 'Current Executing Function' >>>>")
-    # Setting Global configuration Data
-    global configs
-    configs = ConfigsData()
 
     # Get the Primary Keywords from Primary Keywords file
     configs.read_primary_keywords(file_name="primary_keywords.csv")
@@ -661,9 +648,6 @@ def run_data_collector_from_list(
 
         total_key_runs, success_key_runs = 0, 0
 
-        # Setting Global configuration Data
-        global configs
-        configs = ConfigsData()
         for primary_keyword in primary_keywords:
             if primary_keyword is None:
                 continue
@@ -825,6 +809,13 @@ if __name__ == "__main__":
     setup_logger(log_level, console_logging)
 
     logger.info("xGitGuard Public Keys and Token Data Collection Process Started")
+
+    configs = ConfigsData()
+    githubCalls = GithubCalls(
+        configs.xgg_configs["github"]["public_api_url"],
+        "public",
+        configs.xgg_configs["github"]["public_commits_url"],
+    )
 
     valid_config, token_var = check_github_token_env("public")
     if not valid_config:

--- a/xgitguard/ml_training/ml_data-collector/github-public-ml-data_collector/public_key_data_collector.py
+++ b/xgitguard/ml_training/ml_data-collector/github-public-ml-data_collector/public_key_data_collector.py
@@ -815,6 +815,7 @@ if __name__ == "__main__":
         configs.xgg_configs["github"]["public_api_url"],
         "public",
         configs.xgg_configs["github"]["public_commits_url"],
+        configs.xgg_configs["github"]["throttle_time"],
     )
 
     valid_config, token_var = check_github_token_env("public")


### PR DESCRIPTION
### Issue
Improve usability. 
A github public user will almost always have to increase the timeout between API calls. However, in order to do that, they'll have to edit multiple lines of code. This means they have to fork and maintain a copy of xGitGuard.

### Solution
Adding a new parameter (github.throttle_time) so the change can be made in once place. This also means the config can be edited after a clone, only one line needs to change.

### Notes
Converted github_calls into an object in order to keep the number of parameters from going overboard. Also, I don't have an enterprise account, so I cannot test the enterprise functions.