### PR TITLE
Branch Specfic Scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,20 @@ python enterprise_cred_detections.py -o org_name        #Ex: python enterprise_c
 python enterprise_cred_detections.py -r org_name/repo_name     #Ex: python enterprise_cred_detections.py -r test_org/public_docker
 ```
 
+##### Command to Run Enterprise Credentials Scanner for a specific branch
+
+```
+# Run for a specific branch,
+python enterprise_cred_detections.py -r org_name/repo_name -b branch_name     #Ex: python enterprise_cred_detections.py -r test_org/public_docker -b develop
+```
+
+> **Note:** If the specified branch does not exist in the repo, the scanner will exit with an error.
+
 ##### Command-Line Arguments for Credential Scanner
 
 ```
 Run usage:
-enterprise_cred_detections.py [-h] [-s Secondary Keywords] [-e Extensions] [-m Ml prediction] [-u Unmask Secret] [-o org_name] [-r repo_name] [-l Logger Level] [-c Console Logging]
+enterprise_cred_detections.py [-h] [-s Secondary Keywords] [-e Extensions] [-m Ml prediction] [-u Unmask Secret] [-o org_name] [-r repo_name] [-b Branch] [-l Logger Level] [-c Console Logging]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -194,6 +203,8 @@ optional arguments:
                           Pass the flag as Yes or No. Default is No
   -o pass org name, --org Pass the targeted org list as a comma-separated string
   -r pass repo name, --repo Pass the targeted repo list as a comma-separated string
+  -b Branch, --branch Branch
+                          Pass the Branch name to scan. If the branch does not exist, the scanner will exit with an error
   -l Logger Level, --log_level Logger Level
                           Pass the Logging level as for CRITICAL - 50, ERROR - 40 WARNING - 30 INFO - 20 DEBUG - 10. Default is 20
   -c Console Logging, --console_logging Console Logging
@@ -234,6 +245,15 @@ python enterprise_key_detections.py -o org_name        #Ex: python enterprise_ke
 python enterprise_key_detections.py -r org_name/repo_name     #Ex: python enterprise_key_detections.py -r test_org/public_docker
 ```
 
+##### Command to Run Enterprise Keys and Tokens Scanner for a specific branch
+
+```
+# Run for a specific branch,
+python enterprise_key_detections.py -r org_name/repo_name -b branch_name     #Ex: python enterprise_key_detections.py -r test_org/public_docker -b develop
+```
+
+> **Note:** If the specified branch does not exist in the repo, the scanner will exit with an error.
+
 ##### Detections With ML Filter
 
 xGitGuard also has an additional ML filter where users can collect their organization/targeted data and train their model. Having this ML filter helps in reducing the false positives from the detection.
@@ -260,7 +280,7 @@ python enterprise_key_detections.py -m Yes
 
 ```
 Run usage:
-enterprise_key_detections.py [-h] [-s Secondary Keywords] [-e Extensions] [-m Ml prediction] [-u Unmask Secret] [-o org_name] [-r repo_name] [-l Logger Level] [-c Console Logging]
+enterprise_key_detections.py [-h] [-s Secondary Keywords] [-e Extensions] [-m Ml prediction] [-u Unmask Secret] [-o org_name] [-r repo_name] [-b Branch] [-l Logger Level] [-c Console Logging]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -274,6 +294,8 @@ optional arguments:
                           Pass the flag as Yes or No. Default is No
   -o pass org name, --org Pass the targeted org list as a comma-separated string
   -r pass repo name, --repo Pass the targeted repo list as a comma-separated string
+  -b Branch, --branch Branch
+                          Pass the Branch name to scan. If the branch does not exist, the scanner will exit with an error
   -l Logger Level, --log_level Logger Level
                           Pass the Logging level as for CRITICAL - 50, ERROR - 40 WARNING - 30 INFO - 20 DEBUG - 10. Default is 20
   -c Console Logging, --console_logging Console Logging
@@ -354,6 +376,15 @@ python public_cred_detections.py -o org_name         #Ex: python public_cred_det
 python public_cred_detections.py -r org_name/repo_name        #Ex: python public_cred_detections.py -r test_org/public_docker
 ```
 
+##### Command to Run Public Credential Scanner for a specific branch
+
+```
+# Run for a specific branch,
+python public_cred_detections.py -r org_name/repo_name -b branch_name        #Ex: python public_cred_detections.py -r test_org/public_docker -b develop
+```
+
+> **Note:** If the specified branch does not exist in the repo, the scanner will exit with an error.
+
 ##### Detections With ML Filter
 
 xGitGuard also has an additional ML filter, where users can collect their organization/targeted data and train their model. Having this ML filter helps in reducing the false positives from the detection.
@@ -379,7 +410,7 @@ python public_cred_detections.py -m Yes
 
 ```
 Run usage:
-usage: public_cred_detections.py [-h] [-p Primary Keywords] [-s Secondary Keywords] [-e Extensions] [-m Ml prediction] [-u Unmask Secret] [-o org_name] [-r repo_name] [-l Logger Level] [-c Console Logging]
+usage: public_cred_detections.py [-h] [-p Primary Keywords] [-s Secondary Keywords] [-e Extensions] [-m Ml prediction] [-u Unmask Secret] [-o org_name] [-r repo_name] [-b Branch] [-l Logger Level] [-c Console Logging]
 
 optional arguments:
 -h, --help show this help message and exit
@@ -395,6 +426,8 @@ Pass the Extensions list as a comma-separated string
                           Pass the flag as Yes or No. Default is No
 -o pass org name, --org Pass the targeted org list as a comma-separated string
 -r pass repo name, --repo Pass the targeted repo list as a comma-separated string
+-b Branch, --branch Branch
+                          Pass the Branch name to scan. If the branch does not exist, the scanner will exit with an error
 -l Logger Level, --log_level Logger Level
 Pass the Logging level as for CRITICAL - 50, ERROR - 40 WARNING - 30 INFO - 20 DEBUG - 10. Default is 20
 -c Console Logging, --console_logging Console Logging
@@ -438,6 +471,15 @@ python public_key_detections.py -o org_name           #Ex: python public_key_det
 python public_key_detections.py -r org_name/repo_name      #Ex: python public_key_detections.py -r test_org/public_docker
 ```
 
+##### Command to Run Public Keys and Tokens Scanner for a specific branch
+
+```
+# Run for a specific branch,
+python public_key_detections.py -r org_name/repo_name -b branch_name      #Ex: python public_key_detections.py -r test_org/public_docker -b develop
+```
+
+> **Note:** If the specified branch does not exist in the repo, the scanner will exit with an error.
+
 ##### Detections With ML Filter
 
 xGitGuard also has an additional ML filter, where users can collect their organization/targeted data and train their model. Having this ML filter helps in reducing the false positives from the detection.
@@ -462,7 +504,7 @@ python public_key_detections.py -m Yes
 
 ```
 usage:
-public_key_detections.py [-h] [-s Secondary Keywords] [-e Extensions] [-m Ml prediction][-u Unmask Secret] [-o org_name] [-r repo_name] [-l Logger Level] [-c Console Logging]
+public_key_detections.py [-h] [-s Secondary Keywords] [-e Extensions] [-m Ml prediction][-u Unmask Secret] [-o org_name] [-r repo_name] [-b Branch] [-l Logger Level] [-c Console Logging]
 
 optional arguments:
 -h, --help show this help message and exit
@@ -476,6 +518,8 @@ Pass the Extensions list as a comma-separated string
                           Pass the flag as Yes or No. Default is No
 -o pass org name, --org Pass the targeted org list as a comma-separated string
 -r pass repo name, --repo Pass the targeted repo list as a comma-separated string
+-b Branch, --branch Branch
+                          Pass the Branch name to scan. If the branch does not exist, the scanner will exit with an error
 -l Logger Level, --log_level Logger Level
 Pass the Logging level as for CRITICAL - 50, ERROR - 40 WARNING - 30 INFO - 20 DEBUG - 10. Default is 20
 -c Console Logging, --console_logging Console Logging

--- a/xgitguard/common/github_calls.py
+++ b/xgitguard/common/github_calls.py
@@ -325,3 +325,61 @@ class GithubCalls:
         except Exception as e:
             logger.error(f"Github API commit content get Error: {e}")
         return {}
+
+    def check_public_branch_exists(self, user_name, repo_name, branch):
+        """
+        Check if a branch exists in a public GitHub repository
+        params: user_name - string
+        params: repo_name - string
+        params: branch - string
+        returns: True if branch exists, False otherwise
+        """
+        logger.debug("<<<< 'Current Executing Function' >>>>")
+        token_var = "GITHUB_TOKEN"
+        if not os.getenv(token_var):
+            logger.error(
+                f"GitHub API Token Environment variable '{token_var}' not set."
+            )
+            return False
+        try:
+            time.sleep(self._throttle_time)
+            base = self._base_url.replace("/search/code", "")
+            url = f"{base}/repos/{user_name}/{repo_name}/branches/{branch}"
+            response = requests.get(
+                url, auth=("token", os.getenv(token_var)), timeout=10
+            )
+            return response.status_code == 200
+        except Exception as e:
+            logger.error(f"Public branch existence check failed for '{user_name}/{repo_name}' branch '{branch}': {e}")
+            return False
+
+    def check_enterprise_branch_exists(self, user_name, repo_name, branch, header):
+        """
+        Check if a branch exists in an enterprise GitHub repository
+        params: user_name - string
+        params: repo_name - string
+        params: branch - string
+        params: header - dict
+        returns: True if branch exists, False otherwise
+        """
+        logger.debug("<<<< 'Current Executing Function' >>>>")
+        token_var = "GITHUB_ENTERPRISE_TOKEN"
+        if not os.getenv(token_var):
+            logger.error(
+                f"GitHub API Token Environment variable '{token_var}' not set."
+            )
+            return False
+        try:
+            time.sleep(self._throttle_time)
+            base = self._base_url.replace("/search/code", "")
+            url = f"{base}/repos/{user_name}/{repo_name}/branches/{branch}"
+            response = requests.get(
+                url,
+                auth=("token", os.getenv(token_var)),
+                headers=header,
+                timeout=10,
+            )
+            return response.status_code == 200
+        except Exception as e:
+            logger.error(f"Enterprise branch existence check failed for '{user_name}/{repo_name}' branch '{branch}': {e}")
+            return False

--- a/xgitguard/config/xgg_configs.yaml
+++ b/xgitguard/config/xgg_configs.yaml
@@ -7,6 +7,7 @@ github:
   # GitHub Public
   public_api_url: "https://api.github.com/search/code"
   public_commits_url: "https://api.github.com/repos/%s/%s/commits?path=%s"
+  public_pre_url: "https://api.github.com/repos/"
 
   # GitHub Enterprise - For Open Source
   enterprise_api_url: "https://github.<< Enterprise Name >>.com/api/v3/search/code"

--- a/xgitguard/github-enterprise/enterprise_cred_detections.py
+++ b/xgitguard/github-enterprise/enterprise_cred_detections.py
@@ -922,8 +922,8 @@ if __name__ == "__main__":
             if githubCalls.check_enterprise_branch_exists(repo_parts[0], repo_parts[1], branch, header):
                 logger.info(f"Branch '{branch}' exists in repo '{repo[0]}'. Scanning branch '{branch}'.")
             else:
-                logger.warning(f"Branch '{branch}' not found in repo '{repo[0]}'. Falling back to default branch.")
-                branch = ""
+                logger.error(f"Branch '{branch}' not found in repo '{repo[0]}'. Please provide a valid branch name")
+                sys.exit(1)
     elif branch and not repo:
         logger.info(f"Branch '{branch}' specified. Will attempt to scan files on this branch.")
 

--- a/xgitguard/github-enterprise/enterprise_cred_detections.py
+++ b/xgitguard/github-enterprise/enterprise_cred_detections.py
@@ -370,7 +370,7 @@ def check_existing_detections(org_url_list, url_list, search_query):
     return new_org_url_list, new_urls_list, new_hashed_urls
 
 
-def process_search_results(search_response_lines, search_query, ml_prediction):
+def process_search_results(search_response_lines, search_query, ml_prediction, branch=""):
     """
     For each search response items, process as below
         Get the html urls from the search response
@@ -387,6 +387,7 @@ def process_search_results(search_response_lines, search_query, ml_prediction):
     params: search_response_lines - list
     params: search_query - string
     params: ml_prediction - boolean
+    params: branch - string - optional
 
     returns: detection_writes_per_query - int - Total detections written to file
     returns: new_results_per_query - int - No of new urls per query
@@ -413,6 +414,9 @@ def process_search_results(search_response_lines, search_query, ml_prediction):
             + "/contents/"
             + line["path"]
         )
+        # If branch is specified, add ref parameter to the contents API URL
+        if branch:
+            html_url = html_url + "?ref=" + branch
         url_list.append(html_url)
 
     if url_list:
@@ -540,7 +544,7 @@ def format_search_query_list(secondary_keywords):
 
 
 def run_detection(
-    secondary_keywords=[], extensions=[], ml_prediction=False, org=[], repo=[]
+    secondary_keywords=[], extensions=[], ml_prediction=False, org=[], repo=[], branch=""
 ):
     """
     Run GitHub detections
@@ -655,7 +659,7 @@ def run_detection(
                         new_results_per_query,
                         detections_per_query,
                     ) = process_search_results(
-                        search_response_lines, search_query, ml_prediction
+                        search_response_lines, search_query, ml_prediction, branch
                     )
                     logger.info(
                         f"Detection writes in current search query: {detection_writes_per_query}"
@@ -804,6 +808,16 @@ def arg_parser():
         help="Pass the Console Logging as Yes or No. Default is Yes",
     )
 
+    argparser.add_argument(
+        "-b",
+        "--branch",
+        metavar="Branch Name",
+        action="store",
+        type=str,
+        default="",
+        help="Pass the Branch name to scan. If branch does not exist, falls back to default branch",
+    )
+
     args = argparser.parse_args()
 
     if args.secondary_keywords:
@@ -848,6 +862,8 @@ def arg_parser():
     else:
         console_logging = False
 
+    branch = args.branch.strip() if args.branch else ""
+
     return (
         secondary_keywords,
         extensions,
@@ -857,6 +873,7 @@ def arg_parser():
         repo,
         log_level,
         console_logging,
+        branch,
     )
 
 
@@ -871,6 +888,7 @@ if __name__ == "__main__":
         repo,
         log_level,
         console_logging,
+        branch,
     ) = arg_parser()
 
     # Setting up Logger
@@ -896,6 +914,19 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    run_detection(secondary_keywords, extensions, ml_prediction, org, repo)
+    # Validate branch if specified
+    if branch and repo:
+        repo_parts = repo[0].split("/")
+        if len(repo_parts) == 2:
+            header = configs.xgg_configs["github"]["enterprise_header"]
+            if githubCalls.check_enterprise_branch_exists(repo_parts[0], repo_parts[1], branch, header):
+                logger.info(f"Branch '{branch}' exists in repo '{repo[0]}'. Scanning branch '{branch}'.")
+            else:
+                logger.warning(f"Branch '{branch}' not found in repo '{repo[0]}'. Falling back to default branch.")
+                branch = ""
+    elif branch and not repo:
+        logger.info(f"Branch '{branch}' specified. Will attempt to scan files on this branch.")
+
+    run_detection(secondary_keywords, extensions, ml_prediction, org, repo, branch)
 
     logger.info("xGitGuard Credentials Detection Process Completed")

--- a/xgitguard/github-enterprise/enterprise_key_detections.py
+++ b/xgitguard/github-enterprise/enterprise_key_detections.py
@@ -349,7 +349,7 @@ def check_existing_detections(org_url_list, url_list, search_query):
     return new_org_url_list, new_urls_list, new_hashed_urls
 
 
-def process_search_results(search_response_lines, search_query, ml_prediction):
+def process_search_results(search_response_lines, search_query, ml_prediction, branch=""):
     """
     For each search response items, process as below
         Get the html urls from the search response
@@ -366,6 +366,7 @@ def process_search_results(search_response_lines, search_query, ml_prediction):
     params: search_response_lines - list
     params: search_query - string
     params: ml_prediction - boolean
+    params: branch - string - optional
 
     returns: detection_writes_per_query - int - Total detections written to file
     returns: new_results_per_query - int - No of new urls per query
@@ -392,6 +393,9 @@ def process_search_results(search_response_lines, search_query, ml_prediction):
             + "/contents/"
             + line["path"]
         )
+        # If branch is specified, add ref parameter to the contents API URL
+        if branch:
+            html_url = html_url + "?ref=" + branch
         url_list.append(html_url)
 
     if url_list:
@@ -519,7 +523,7 @@ def format_search_query_list(secondary_keywords):
 
 
 def run_detection(
-    secondary_keywords=[], extensions=[], ml_prediction=False, org=[], repo=[]
+    secondary_keywords=[], extensions=[], ml_prediction=False, org=[], repo=[], branch=""
 ):
     """
     Run GitHub detections
@@ -634,7 +638,7 @@ def run_detection(
                         new_results_per_query,
                         detections_per_query,
                     ) = process_search_results(
-                        search_response_lines, search_query, ml_prediction
+                        search_response_lines, search_query, ml_prediction, branch
                     )
                     logger.info(
                         f"Detection writes in current search query: {detection_writes_per_query}"
@@ -784,6 +788,16 @@ def arg_parser():
         help="Pass the Console Logging as Yes or No. Default is Yes",
     )
 
+    argparser.add_argument(
+        "-b",
+        "--branch",
+        metavar="Branch Name",
+        action="store",
+        type=str,
+        default="",
+        help="Pass the Branch name to scan. If branch does not exist, falls back to default branch",
+    )
+
     args = argparser.parse_args()
 
     if args.secondary_keywords:
@@ -828,6 +842,8 @@ def arg_parser():
     else:
         console_logging = False
 
+    branch = args.branch.strip() if args.branch else ""
+
     return (
         secondary_keywords,
         extensions,
@@ -837,6 +853,7 @@ def arg_parser():
         repo,
         log_level,
         console_logging,
+        branch,
     )
 
 
@@ -851,6 +868,7 @@ if __name__ == "__main__":
         repo,
         log_level,
         console_logging,
+        branch,
     ) = arg_parser()
 
     # Setting up Logger
@@ -876,6 +894,19 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    run_detection(secondary_keywords, extensions, ml_prediction, org, repo)
+    # Validate branch if specified
+    if branch and repo:
+        repo_parts = repo[0].split("/")
+        if len(repo_parts) == 2:
+            header = configs.xgg_configs["github"]["enterprise_header"]
+            if githubCalls.check_enterprise_branch_exists(repo_parts[0], repo_parts[1], branch, header):
+                logger.info(f"Branch '{branch}' exists in repo '{repo[0]}'. Scanning branch '{branch}'.")
+            else:
+                logger.warning(f"Branch '{branch}' not found in repo '{repo[0]}'. Falling back to default branch.")
+                branch = ""
+    elif branch and not repo:
+        logger.info(f"Branch '{branch}' specified. Will attempt to scan files on this branch.")
+
+    run_detection(secondary_keywords, extensions, ml_prediction, org, repo, branch)
 
     logger.info("xGitGuard Enterprise Keys and Token Detection Process Completed")

--- a/xgitguard/github-enterprise/enterprise_key_detections.py
+++ b/xgitguard/github-enterprise/enterprise_key_detections.py
@@ -902,8 +902,8 @@ if __name__ == "__main__":
             if githubCalls.check_enterprise_branch_exists(repo_parts[0], repo_parts[1], branch, header):
                 logger.info(f"Branch '{branch}' exists in repo '{repo[0]}'. Scanning branch '{branch}'.")
             else:
-                logger.warning(f"Branch '{branch}' not found in repo '{repo[0]}'. Falling back to default branch.")
-                branch = ""
+                logger.error(f"Branch '{branch}' not found in repo '{repo[0]}'. Please provide a valid branch name")
+                sys.exit(1)
     elif branch and not repo:
         logger.info(f"Branch '{branch}' specified. Will attempt to scan files on this branch.")
 

--- a/xgitguard/github-public/public_cred_detections.py
+++ b/xgitguard/github-public/public_cred_detections.py
@@ -1100,8 +1100,8 @@ if __name__ == "__main__":
             if githubCalls.check_public_branch_exists(repo_parts[0], repo_parts[1], branch):
                 logger.info(f"Branch '{branch}' exists in repo '{repo[0]}'. Scanning branch '{branch}'.")
             else:
-                logger.warning(f"Branch '{branch}' not found in repo '{repo[0]}'. Falling back to default branch.")
-                branch = ""
+                logger.error(f"Branch '{branch}' not found in repo '{repo[0]}'. Please provide a valid branch name.")
+                sys.exit(1)
     elif branch and not repo:
         logger.info(f"Branch '{branch}' specified. Will attempt to scan files on this branch.")
 

--- a/xgitguard/github-public/public_cred_detections.py
+++ b/xgitguard/github-public/public_cred_detections.py
@@ -369,7 +369,7 @@ def check_existing_detections(url_list, search_query):
     return new_urls_list, new_hashed_urls
 
 
-def process_search_results(search_response_lines, search_query, ml_prediction):
+def process_search_results(search_response_lines, search_query, ml_prediction, branch=""):
     """
     For each search response items, process as below
         Get the html urls from the search response
@@ -386,6 +386,7 @@ def process_search_results(search_response_lines, search_query, ml_prediction):
     params: search_response_lines - list
     params: search_query - string
     params: ml_prediction - boolean
+    params: branch - string - optional
 
     returns: detection_writes_per_query - int - Total detections written to file
     returns: new_results_per_query - int - No of new urls per query
@@ -409,6 +410,12 @@ def process_search_results(search_response_lines, search_query, ml_prediction):
         html_url = html_url.replace(
             "https://github.com", "https://raw.githubusercontent.com"
         )
+        # If branch is specified, replace the branch segment in the raw URL
+        if branch:
+            url_parts = html_url.split("/")
+            if len(url_parts) > 5:
+                url_parts[5] = branch
+                html_url = "/".join(url_parts)
         url_list.append(html_url)
 
     if url_list:
@@ -544,6 +551,7 @@ def run_detection(
     ml_prediction=False,
     org=[],
     repo=[],
+    branch="",
 ):
     """
     Run GitHub detections
@@ -674,6 +682,7 @@ def run_detection(
                         search_response_lines,
                         search_query,
                         ml_prediction,
+                        branch,
                     )
                     logger.info(
                         f"Detection writes in current search query: {detection_writes_per_query}"
@@ -705,7 +714,7 @@ def run_detection(
 
 
 def run_detections_from_file(
-    secondary_keywords=[], extensions=[], ml_prediction=False, org=[], repo=[]
+    secondary_keywords=[], extensions=[], ml_prediction=False, org=[], repo=[], branch=""
 ):
     """
     Run detection for Primary Keywords present in the default config file
@@ -737,6 +746,7 @@ def run_detections_from_file(
                         ml_prediction,
                         org,
                         repo,
+                        branch,
                     )
                     status = True
                 except Exception as e:
@@ -767,6 +777,7 @@ def run_detections_from_list(
     ml_prediction=False,
     org=[],
     repo=[],
+    branch="",
 ):
     """
     Run detection for Primary Keywords present in the given input list
@@ -815,6 +826,7 @@ def run_detections_from_list(
                         ml_prediction,
                         org,
                         repo,
+                        branch,
                     )
                 except Exception as e:
                     logger.error(f"Process Error: {e}")
@@ -967,6 +979,16 @@ def arg_parser():
         help="Pass the Console Logging as Yes or No. Default is Yes",
     )
 
+    argparser.add_argument(
+        "-b",
+        "--branch",
+        metavar="Branch Name",
+        action="store",
+        type=str,
+        default="",
+        help="Pass the Branch name to scan. If branch does not exist, falls back to default branch",
+    )
+
     args = argparser.parse_args()
 
     if args.primary_keywords:
@@ -1015,6 +1037,8 @@ def arg_parser():
     else:
         console_logging = False
 
+    branch = args.branch.strip() if args.branch else ""
+
     return (
         primary_keywords,
         secondary_keywords,
@@ -1025,6 +1049,7 @@ def arg_parser():
         repo,
         log_level,
         console_logging,
+        branch,
     )
 
 
@@ -1040,6 +1065,7 @@ if __name__ == "__main__":
         repo,
         log_level,
         console_logging,
+        branch,
     ) = arg_parser()
 
     # Setting up Logger
@@ -1067,13 +1093,25 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
+    # Validate branch if specified
+    if branch and repo:
+        repo_parts = repo[0].split("/")
+        if len(repo_parts) == 2:
+            if githubCalls.check_public_branch_exists(repo_parts[0], repo_parts[1], branch):
+                logger.info(f"Branch '{branch}' exists in repo '{repo[0]}'. Scanning branch '{branch}'.")
+            else:
+                logger.warning(f"Branch '{branch}' not found in repo '{repo[0]}'. Falling back to default branch.")
+                branch = ""
+    elif branch and not repo:
+        logger.info(f"Branch '{branch}' specified. Will attempt to scan files on this branch.")
+
     if primary_keywords:
         run_detections_from_list(
-            primary_keywords, secondary_keywords, extensions, ml_prediction, org, repo
+            primary_keywords, secondary_keywords, extensions, ml_prediction, org, repo, branch
         )
     else:
         run_detections_from_file(
-            secondary_keywords, extensions, ml_prediction, org, repo
+            secondary_keywords, extensions, ml_prediction, org, repo, branch
         )
 
     logger.info("xGitGuard Credentials Detection Process Completed")

--- a/xgitguard/github-public/public_key_detections.py
+++ b/xgitguard/github-public/public_key_detections.py
@@ -1069,8 +1069,8 @@ if __name__ == "__main__":
             if githubCalls.check_public_branch_exists(repo_parts[0], repo_parts[1], branch):
                 logger.info(f"Branch '{branch}' exists in repo '{repo[0]}'. Scanning branch '{branch}'.")
             else:
-                logger.warning(f"Branch '{branch}' not found in repo '{repo[0]}'. Falling back to default branch.")
-                branch = ""
+                logger.error(f"Branch '{branch}' not found in repo '{repo[0]}'. Please provide a valid branch name.")
+                sys.exit(1)
     elif branch and not repo:
         logger.info(f"Branch '{branch}' specified. Will attempt to scan files on this branch.")
 

--- a/xgitguard/github-public/public_key_detections.py
+++ b/xgitguard/github-public/public_key_detections.py
@@ -342,7 +342,7 @@ def check_existing_detections(url_list, search_query):
     return new_urls_list, new_hashed_urls
 
 
-def process_search_results(search_response_lines, search_query, ml_prediction):
+def process_search_results(search_response_lines, search_query, ml_prediction, branch=""):
     """
     For each search response items, process as below
         Get the html urls from the search response
@@ -359,6 +359,7 @@ def process_search_results(search_response_lines, search_query, ml_prediction):
     params: search_response_lines - list
     params: search_query - string
     params: ml_prediction - boolean
+    params: branch - string - optional
 
     returns: detection_writes_per_query - int - Total detections written to file
     returns: new_results_per_query - int - No of new urls per query
@@ -382,6 +383,12 @@ def process_search_results(search_response_lines, search_query, ml_prediction):
         html_url = html_url.replace(
             "https://github.com", "https://raw.githubusercontent.com"
         )
+        # If branch is specified, replace the branch segment in the raw URL
+        if branch:
+            url_parts = html_url.split("/")
+            if len(url_parts) > 5:
+                url_parts[5] = branch
+                html_url = "/".join(url_parts)
         url_list.append(html_url)
 
     if url_list:
@@ -517,6 +524,7 @@ def run_detection(
     ml_prediction=False,
     org=[],
     repo=[],
+    branch="",
 ):
     """
     Run GitHub detections
@@ -645,7 +653,7 @@ def run_detection(
                         new_results_per_query,
                         detections_per_query,
                     ) = process_search_results(
-                        search_response_lines, search_query, ml_prediction
+                        search_response_lines, search_query, ml_prediction, branch
                     )
                     logger.info(
                         f"Detection writes in current search query: {detection_writes_per_query}"
@@ -677,7 +685,7 @@ def run_detection(
 
 
 def run_detections_from_file(
-    secondary_keywords=[], extensions=[], ml_prediction=False, org=[], repo=[]
+    secondary_keywords=[], extensions=[], ml_prediction=False, org=[], repo=[], branch=""
 ):
     """
     Run detection for Primary Keywords present in the default config file
@@ -709,6 +717,7 @@ def run_detections_from_file(
                         ml_prediction,
                         org,
                         repo,
+                        branch,
                     )
                     status = True
                 except Exception as e:
@@ -739,6 +748,7 @@ def run_detections_from_list(
     ml_prediction=False,
     org=[],
     repo=[],
+    branch="",
 ):
     """
     Run detection for Primary Keywords present in the given input list
@@ -787,6 +797,7 @@ def run_detections_from_list(
                         ml_prediction,
                         org,
                         repo,
+                        branch,
                     )
                 except Exception as e:
                     logger.error(f"Process Error: {e}")
@@ -937,6 +948,16 @@ def arg_parser():
         help="Pass the Console Logging as Yes or No. Default is Yes",
     )
 
+    argparser.add_argument(
+        "-b",
+        "--branch",
+        metavar="Branch Name",
+        action="store",
+        type=str,
+        default="",
+        help="Pass the Branch name to scan. If branch does not exist, falls back to default branch",
+    )
+
     args = argparser.parse_args()
 
     if args.primary_keywords:
@@ -985,6 +1006,8 @@ def arg_parser():
     else:
         console_logging = False
 
+    branch = args.branch.strip() if args.branch else ""
+
     return (
         primary_keywords,
         secondary_keywords,
@@ -995,6 +1018,7 @@ def arg_parser():
         repo,
         log_level,
         console_logging,
+        branch,
     )
 
 
@@ -1010,6 +1034,7 @@ if __name__ == "__main__":
         repo,
         log_level,
         console_logging,
+        branch,
     ) = arg_parser()
 
     # Setting up Logger
@@ -1037,13 +1062,25 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
+    # Validate branch if specified
+    if branch and repo:
+        repo_parts = repo[0].split("/")
+        if len(repo_parts) == 2:
+            if githubCalls.check_public_branch_exists(repo_parts[0], repo_parts[1], branch):
+                logger.info(f"Branch '{branch}' exists in repo '{repo[0]}'. Scanning branch '{branch}'.")
+            else:
+                logger.warning(f"Branch '{branch}' not found in repo '{repo[0]}'. Falling back to default branch.")
+                branch = ""
+    elif branch and not repo:
+        logger.info(f"Branch '{branch}' specified. Will attempt to scan files on this branch.")
+
     if primary_keywords:
         run_detections_from_list(
-            primary_keywords, secondary_keywords, extensions, ml_prediction, org, repo
+            primary_keywords, secondary_keywords, extensions, ml_prediction, org, repo, branch
         )
     else:
         run_detections_from_file(
-            secondary_keywords, extensions, ml_prediction, org, repo
+            secondary_keywords, extensions, ml_prediction, org, repo, branch
         )
 
     logger.info("xGitGuard Keys and Token Detection Process Completed")


### PR DESCRIPTION
Added the branch-specific scanning support for public and enterprise detections
Implemented the check for public_branch_exists and check_enterprise_branch_exists.
Added the -b --branch CLI argument to all detection scripts.
Validate the branch existence before scanning, if not scan the default branch.